### PR TITLE
Fix: Correct label overlap in authentication forms

### DIFF
--- a/lib/core/app_theme.dart
+++ b/lib/core/app_theme.dart
@@ -10,6 +10,7 @@ class AppTheme {
       ),
       inputDecorationTheme: const InputDecorationTheme(
         border: OutlineInputBorder(),
+        floatingLabelBehavior: FloatingLabelBehavior.auto,
       ),
       filledButtonTheme: FilledButtonThemeData(
         style: FilledButton.styleFrom(

--- a/lib/features/auth/auth_page.dart
+++ b/lib/features/auth/auth_page.dart
@@ -127,6 +127,7 @@ class _LoginFormState extends State<_LoginForm> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
+          const SizedBox(height: 8),
           TextFormField(
             controller: _emailController,
             decoration: const InputDecoration(labelText: 'E-mail'),
@@ -138,7 +139,7 @@ class _LoginFormState extends State<_LoginForm> {
               return null;
             },
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: 20),
           TextFormField(
             controller: _passwordController,
             decoration: const InputDecoration(labelText: 'Senha'),
@@ -213,6 +214,7 @@ class _SignUpFormState extends State<_SignUpForm> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
+          const SizedBox(height: 8),
           TextFormField(
             controller: _nameController,
             decoration: const InputDecoration(labelText: 'Nome completo'),
@@ -223,7 +225,7 @@ class _SignUpFormState extends State<_SignUpForm> {
               return null;
             },
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: 20),
           TextFormField(
             controller: _emailController,
             decoration: const InputDecoration(labelText: 'E-mail'),
@@ -235,7 +237,7 @@ class _SignUpFormState extends State<_SignUpForm> {
               return null;
             },
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: 20),
           TextFormField(
             controller: _passwordController,
             decoration: const InputDecoration(labelText: 'Senha'),


### PR DESCRIPTION
## Description
This PR fixes the label overlap issue in the login and sign-up forms reported in #1.

## Changes Made
- Added `floatingLabelBehavior: FloatingLabelBehavior.auto` to `InputDecorationTheme` in `app_theme.dart` to ensure labels float correctly above the input fields
- Increased spacing between form fields from 12px to 20px for better visual separation
- Added 8px top padding to both login and sign-up forms

## Screenshots
The labels now properly float above the input fields when users interact with them, preventing the overlap shown in the issue screenshots.

## Related Issue
Closes #1