### PR TITLE
Fix: Support weights less than 1kg in workouts and ranking

### DIFF
--- a/lib/features/ranking/ranking_page.dart
+++ b/lib/features/ranking/ranking_page.dart
@@ -254,10 +254,13 @@ class _RankingPageState extends State<RankingPage> {
   String _formatVolume(double volume) {
     if (volume >= 1000000) {
       return '${(volume / 1000000).toStringAsFixed(1)}M';
-    } else if (volume >= 1000) {
+    }
+    if (volume >= 1000) {
       return '${(volume / 1000).toStringAsFixed(1)}K';
-    } else {
+    }
+    if (volume >= 1) {
       return volume.toStringAsFixed(0);
     }
+    return volume.toStringAsFixed(1);
   }
 }

--- a/lib/features/workouts/workout_form_sheet.dart
+++ b/lib/features/workouts/workout_form_sheet.dart
@@ -182,13 +182,19 @@ class _WorkoutFormSheetState extends State<WorkoutFormSheet> {
                                   Expanded(
                                     child: TextFormField(
                                       controller: item.weight,
-                                      decoration: const InputDecoration(labelText: 'Peso (kg)'),
+                                      decoration: const InputDecoration(
+                                        labelText: 'Peso (kg)',
+                                        helperText: 'Ex: 0.5 ou 10',
+                                      ),
                                       keyboardType:
                                           const TextInputType.numberWithOptions(decimal: true, signed: false),
                                       validator: (value) {
                                         final parsed = double.tryParse(value ?? '');
-                                        if (parsed == null || parsed < 0) {
-                                          return 'Inválido';
+                                        if (parsed == null) {
+                                          return 'Valor inválido';
+                                        }
+                                        if (parsed < 0) {
+                                          return 'Deve ser >= 0';
                                         }
                                         return null;
                                       },
@@ -246,7 +252,7 @@ class _ExerciseFormData {
         muscleGroup = kMuscleGroups.first,
         sets = TextEditingController(text: '3'),
         reps = TextEditingController(text: '10'),
-        weight = TextEditingController(text: '0'),
+        weight = TextEditingController(),
         rest = TextEditingController(text: '60');
 
   _ExerciseFormData.fromExercise(ExerciseEntry exercise)

--- a/lib/features/workouts/workouts_calendar_page.dart
+++ b/lib/features/workouts/workouts_calendar_page.dart
@@ -234,8 +234,8 @@ class _DetailsSection extends StatelessWidget {
                             subtitle: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                Text('${exercise.muscleGroup} • ${exercise.sets}x${exercise.reps} • ${exercise.weightKg}kg'),
-                                Text('Volume: ${exercise.volume.toStringAsFixed(0)} kg'),
+                                Text('${exercise.muscleGroup} • ${exercise.sets}x${exercise.reps} • ${_formatWeight(exercise.weightKg)}kg'),
+                                Text('Volume: ${exercise.volume.toStringAsFixed(1)} kg'),
                               ],
                             ),
                             trailing: Text('${exercise.restSeconds}s'),
@@ -282,4 +282,11 @@ class _DetailsSection extends StatelessWidget {
       ),
     );
   }
+}
+
+String _formatWeight(double weight) {
+  if (weight >= 1) {
+    return weight.toStringAsFixed(0);
+  }
+  return weight.toStringAsFixed(1);
 }


### PR DESCRIPTION
## Description
This PR fixes the issue where weights less than 1kg could not be properly entered or displayed in the workout tracking system.

## Changes Made

### Workout Form (`workout_form_sheet.dart`)
- Updated weight input validation to properly accept decimal values (e.g., 0.5 kg)
- Added helper text `"Ex: 0.5 ou 10"` to guide users on acceptable input formats
- Improved validation error messages for better clarity
- Removed default weight value of `"0"` to encourage explicit user input

### Workout Calendar Display (`workouts_calendar_page.dart`)
- Added `_formatWeight()` helper function to properly format weight display
  - Values >= 1kg: shown without decimals (e.g., "10 kg")
  - Values < 1kg: shown with 1 decimal place (e.g., "0.5 kg")
- Updated volume display to show 1 decimal place for better precision

### Ranking Display (`ranking_page.dart`)
- Updated `_formatVolume()` function using early returns (no else statements)
- Added proper formatting for values < 1kg to display with 1 decimal place
- Maintains existing formatting for larger values (K for thousands, M for millions)

## Examples
- **Before**: User couldn't see "0.5 kg" properly displayed (would show as "0 kg")
- **After**: "0.5 kg" displays correctly, allowing proper tracking of lighter weights like dumbbells, resistance bands, etc.

## Related Issue
Closes #2